### PR TITLE
일기 삭제 할 때 관련 테이블도 같이 삭제되게 변경

### DIFF
--- a/app.py
+++ b/app.py
@@ -344,6 +344,10 @@ async def delete_temp_diary(diary_id: int, db: Session = Depends(get_db)):
     
     if not diary:
         raise HTTPException(status_code=404, detail="일기를 찾을 수 없습니다.")
+    
+    # 관련 emotions와 psy 삭제
+    db.query(models.Emotion).filter(models.Emotion.diary_id == diary_id).delete()
+    db.query(models.Psy).filter(models.Psy.diary_id == diary_id).delete()
 
     # 삭제 수행
     db.delete(diary)

--- a/models.py
+++ b/models.py
@@ -1,6 +1,7 @@
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Boolean, Table, Text, BLOB, event
 from sqlalchemy.sql import func
 from database import Base
+from sqlalchemy.orm import relationship
 
 class User(Base):
     __tablename__ = 'users'
@@ -45,6 +46,8 @@ class Emotion(Base):
     boredom = Column(Integer, default=0)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
+    
+
 class Psy(Base):
     __tablename__ = 'psy'
     psy_id = Column(Integer, primary_key=True, index=True, autoincrement=True)
@@ -69,13 +72,3 @@ class ShareDiary(Base):
     content = Column(Text)
     flag = Column(Boolean, default=False)
     created_at = Column(DateTime)
-
-# diary의 photo가 업데이트 되면 자동으로 share_diary의 photo가 업데이트
-# @event.listens_for(Diary, 'after_update')
-# def update_share_diary_photo(connection, target):
-#     # target은 업데이트된 Diary 인스턴스
-#     connection.execute(
-#         ShareDiary.__table__.update()
-#         .where(ShareDiary.diary_id == target.diary_id)
-#         .values(photo=target.photo)
-#     )


### PR DESCRIPTION
일기 삭제 할 때 관련 테이블도 같이 삭제되게 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 일기 삭제 시 해당 일기와 연관된 감정 및 심리 데이터도 함께 삭제되어 데이터 정합성이 향상되었습니다.

- **정리**
  - 사용되지 않는 코드 및 주석이 제거되어 코드가 더 깔끔해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->